### PR TITLE
Make the build noarch again

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,8 @@ project('eglexternalplatform',
 pkg = import('pkgconfig')
 pkg.generate(filebase: 'eglexternalplatform',
   name: 'EGL External Platform interface',
-  description: 'EGL External Platform interface')
+  description: 'EGL External Platform interface',
+  install_dir: get_option('datadir') / 'pkgconfig')
 
 install_headers(
   'interface/eglexternalplatform.h',


### PR DESCRIPTION
With the autogeneration of the `pkg-config` file, depending on the architecture you build the package, the file gets installed in one of the architecure dependent folders (`/usr/lib64/pkgconfig`, `/usr/lib/pkgconfig`, `/usr/lib/x86_64-linux-gnu/pkgconfig/`, etc.). This means it would require one build for architecture.

Make it `noarch` again (it's just headers) by forcing the installation of the `pkg-config` file in `/usr/share/pkgconfig`.

All distributions shipped the package as a `noarch` build before 1.2.